### PR TITLE
Add sprite-selector and current-statement2 to [M] Dark.json

### DIFF
--- a/[M] Dark.json
+++ b/[M] Dark.json
@@ -1,6 +1,6 @@
 {
   "name": "Dark Theme (Visual Studio Dark) - Modern",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "background": "#252526",
   "global": {
     "background": "#2d2d30",
@@ -247,6 +247,19 @@
       "foreground": "#f1f1f1"
     }
   },
+  "sprite-selector": {
+    "background": "#2d2d30",
+    "foreground": "#f1f1f1",
+    "list": {
+      "background": "#252525",
+      "foreground": "#f1f1f1"
+    },
+    "tree": {
+      "background": "#252525",
+      "foreground": "#f1f1f1",
+      "line": "#2d2d30"
+    }
+  },
   "script-editor": {
     "background": "#161e20",
     "foreground": "#c8c8c8",
@@ -364,6 +377,10 @@
       "current-statement": {
         "background": "#71571b",
         "foreground": "#3f4e49"
+      },
+      "current-statement-2": {
+        "background": "#71571b",
+        "foreground": "transparent"
       }
     }
   }


### PR DESCRIPTION
This fixes a couple of configurations missing from the modern dark theme:
* Adds the sprite-selector configuration
* Adds the current-statement2 configuration (although this may not be working, see: https://github.com/adventuregamestudio/ags/issues/1974)

Finally, bumps version to 0.0.2